### PR TITLE
Revert rambafile

### DIFF
--- a/iOS/Examples/Rambafile
+++ b/iOS/Examples/Rambafile
@@ -12,10 +12,10 @@ project_targets:
 - PROJECTNAMEPlayground
 
 # The file path for new modules
-project_file_path: PROJECTNAME/Generated
+project_file_path: PROJECTNAME/Controllers
 
 # The Xcode group path to new modules
-project_group_path: PROJECTNAME/Generated
+project_group_path: PROJECTNAME/Controllers
 
 ### Dependencies settings section
 podfile_path: Podfile


### PR DESCRIPTION
Необходимо вернуть обратно, поскольку при фазе генератора чистится вся папка `Generated`, что вызывает удаление сгенерированной папки контроллера/ячейки. Обычное перетягивание в Xcode лишь меняет пути. Лучше оставить как было